### PR TITLE
Fix/short code jump to (commit to ask questions)

### DIFF
--- a/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
+++ b/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
@@ -184,12 +184,12 @@ add_action( 'save_post_interactives', 'interactive_save_meta_box_data' );
  * @param  String  $interactiveURL       URL to the interactive
  * @param  String  $width                Width of the iframe, can be in px or %
  * @param  String  $height               Height of the iframe, can be in px or %
+ * @param	 String  $iframeID	           ID of iFrame
  * @param  String  $fallbackImg          Featured image thumbnail img tag string
  * @param  boolean $iframeResizeDisabled Indicate if iframe should automatically resize based on content height
- * @param	 String  $iframeID	           ID of iFrame
  * @return String                        HTML of the iframe
  */
-function chinapower_interactive_display_iframe($interactiveURL, $width, $height, $fallbackImg = null, $iframeResizeDisabled = false, $iframeID) {
+function chinapower_interactive_display_iframe($interactiveURL, $width, $height, $iframeID, $fallbackImg = null, $iframeResizeDisabled = false) {
 
 	if(empty($width)) {
 		$width = "100%";
@@ -204,7 +204,6 @@ function chinapower_interactive_display_iframe($interactiveURL, $width, $height,
 	}
 
 	if($iframeID) {
-		// $iframeID = 'id= "'.$iframeID.'"';
 		echo "<script>console.log( 'iframeID worked " . $iframeID . "' );</script>";
 	}
 

--- a/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
+++ b/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
@@ -1,4 +1,4 @@
-<?php
+ranch<?php
 /**
  * Custom Post Types: Interactives
  *
@@ -214,7 +214,7 @@ function chinapower_interactive_display_iframe($interactiveURL, $width, $height,
 		$enabledClass = " js-iframeResizeEnabled";
 	}
 
-	return $fallbackImg.'<iframe class="interactive-iframe'.$enabledClass.'" width="'.$width.'" '.$heightValue.' scrolling="no" frameborder="no" id="'.$iframeID.'" id="jump" src="'.$interactiveURL.'"></iframe>';
+	return $fallbackImg.'<iframe class="interactive-iframe'.$enabledClass.'" width="'.$width.'" '.$heightValue.' scrolling="no" frameborder="no" id="'.$iframeID.'" src="'.$interactiveURL.'"></iframe>';
 }
 
 /*----------  Display Generate Shortcode Button  ----------*/

--- a/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
+++ b/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
@@ -185,11 +185,11 @@ add_action( 'save_post_interactives', 'interactive_save_meta_box_data' );
  * @param  String  $width                Width of the iframe, can be in px or %
  * @param  String  $height               Height of the iframe, can be in px or %
  * @param  String  $fallbackImg          Featured image thumbnail img tag string
- * @param	 String  $iframeTitle          Title of iFrame
  * @param  boolean $iframeResizeDisabled Indicate if iframe should automatically resize based on content height
+ * @param	 String  $iframeID	           ID of iFrame
  * @return String                        HTML of the iframe
  */
-function chinapower_interactive_display_iframe($interactiveURL, $width, $height, $fallbackImg = null, $iframeResizeDisabled = false) {
+function chinapower_interactive_display_iframe($interactiveURL, $width, $height, $fallbackImg = null, $iframeResizeDisabled = false, $iframeID) {
 
 	if(empty($width)) {
 		$width = "100%";
@@ -203,6 +203,11 @@ function chinapower_interactive_display_iframe($interactiveURL, $width, $height,
 		$fallbackImg = '<div class="interactive-fallbackImg">'.$fallbackImg.'<p>For best experience, please view on a desktop computer.</p></div>';
 	}
 
+	if($iframeID) {
+		// $iframeID = 'id= "'.$iframeID.'"';
+		echo "<script>console.log( 'iframeID worked " . $iframeID . "' );</script>";
+	}
+
 	if($iframeResizeDisabled) {
 		$enabledClass = "";
 	}
@@ -210,7 +215,7 @@ function chinapower_interactive_display_iframe($interactiveURL, $width, $height,
 		$enabledClass = " js-iframeResizeEnabled";
 	}
 
-	return $fallbackImg.'<iframe class="interactive-iframe'.$enabledClass.'" width="'.$width.'" '.$heightValue.' scrolling="no" frameborder="no" id="'.$iframeTitle.'" src="'.$interactiveURL.'"></iframe>';
+	return $fallbackImg.'<iframe class="interactive-iframe'.$enabledClass.'" width="'.$width.'" '.$heightValue.' scrolling="no" frameborder="no" id="'.$iframeID.'" src="'.$interactiveURL.'"></iframe>';
 }
 
 /*----------  Display Generate Shortcode Button  ----------*/

--- a/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
+++ b/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
@@ -1,4 +1,4 @@
-ranch<?php
+<?php
 /**
  * Custom Post Types: Interactives
  *

--- a/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
+++ b/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
@@ -52,7 +52,7 @@ function chinapower_cpt_interactives() {
 		'show_in_admin_bar'     => true,
 		'show_in_nav_menus'     => true,
 		'can_export'            => true,
-		'has_archive'           => true,		
+		'has_archive'           => true,
 		'exclude_from_search'   => true,
 		'publicly_queryable'    => true,
 		'capability_type'       => 'post',
@@ -100,12 +100,12 @@ function interactive_build_meta_box( $post ){
 
 		<h3><?php _e( 'iFrame Width', 'chinapower' ); ?></h3>
 		<p>
-			<input type="text" class="large-text" name="width" value="<?php echo $current_width; ?>" /> 
+			<input type="text" class="large-text" name="width" value="<?php echo $current_width; ?>" />
 		</p>
 
 		<h3><?php _e( 'iFrame Height', 'chinapower' ); ?></h3>
 		<p>
-			<input type="text" class="large-text" name="height" value="<?php echo $current_height; ?>" /> 
+			<input type="text" class="large-text" name="height" value="<?php echo $current_height; ?>" />
 		</p>
 		<p>
 			<input type="checkbox" name="iframeResizeDisabled" value="1" <?php checked( $current_iframeResizeDisabled, '1' ); ?> /> Disable autoheight resizing?
@@ -185,6 +185,7 @@ add_action( 'save_post_interactives', 'interactive_save_meta_box_data' );
  * @param  String  $width                Width of the iframe, can be in px or %
  * @param  String  $height               Height of the iframe, can be in px or %
  * @param  String  $fallbackImg          Featured image thumbnail img tag string
+ * @param	 String  $iframeTitle          Title of iFrame
  * @param  boolean $iframeResizeDisabled Indicate if iframe should automatically resize based on content height
  * @return String                        HTML of the iframe
  */
@@ -209,7 +210,7 @@ function chinapower_interactive_display_iframe($interactiveURL, $width, $height,
 		$enabledClass = " js-iframeResizeEnabled";
 	}
 
-	return $fallbackImg.'<iframe class="interactive-iframe'.$enabledClass.'" width="'.$width.'" '.$heightValue.' scrolling="no" frameborder="no" src="'.$interactiveURL.'"></iframe>';
+	return $fallbackImg.'<iframe class="interactive-iframe'.$enabledClass.'" width="'.$width.'" '.$heightValue.' scrolling="no" frameborder="no" id="'.$iframeTitle.'" src="'.$interactiveURL.'"></iframe>';
 }
 
 /*----------  Display Generate Shortcode Button  ----------*/

--- a/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
+++ b/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
@@ -203,10 +203,6 @@ function chinapower_interactive_display_iframe($interactiveURL, $width, $height,
 		$fallbackImg = '<div class="interactive-fallbackImg">'.$fallbackImg.'<p>For best experience, please view on a desktop computer.</p></div>';
 	}
 
-	if($iframeID) {
-		echo "<script>console.log( 'iframeID worked " . $iframeID . "' );</script>";
-	}
-
 	if($iframeResizeDisabled) {
 		$enabledClass = "";
 	}

--- a/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
+++ b/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
@@ -204,7 +204,7 @@ function chinapower_interactive_display_iframe($interactiveURL, $width, $height,
 	}
 
 	if($iframeID) {
- 		echo "<script>console.log( 'iframeID worked " . $iframeID . "' );</script>";
+		echo "<script>console.log( 'iframeID worked " . $iframeID . "' );</script>";
 	}
 
 	if($iframeResizeDisabled) {
@@ -214,7 +214,7 @@ function chinapower_interactive_display_iframe($interactiveURL, $width, $height,
 		$enabledClass = " js-iframeResizeEnabled";
 	}
 
-	return $fallbackImg.'<iframe class="interactive-iframe'.$enabledClass.'" width="'.$width.'" '.$heightValue.' scrolling="no" frameborder="no" id="'.$iframeID.'" src="'.$interactiveURL.'"></iframe>';
+	return $fallbackImg.'<iframe class="interactive-iframe'.$enabledClass.'" width="'.$width.'" '.$heightValue.' scrolling="no" frameborder="no" id="'.$iframeID.'" id="jump" src="'.$interactiveURL.'"></iframe>';
 }
 
 /*----------  Display Generate Shortcode Button  ----------*/

--- a/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
+++ b/wp-content/themes/chinapower/inc/cpts/cpt-interactives.php
@@ -204,7 +204,7 @@ function chinapower_interactive_display_iframe($interactiveURL, $width, $height,
 	}
 
 	if($iframeID) {
-		echo "<script>console.log( 'iframeID worked " . $iframeID . "' );</script>";
+ 		echo "<script>console.log( 'iframeID worked " . $iframeID . "' );</script>";
 	}
 
 	if($iframeResizeDisabled) {

--- a/wp-content/themes/chinapower/inc/custom-shortcodes.php
+++ b/wp-content/themes/chinapower/inc/custom-shortcodes.php
@@ -162,13 +162,18 @@ function chinapower_shortcode_interactive( $atts ) {
 
 	if($atts['toc'] === true || $atts['toc'] == 'true') {
 		$heading = '<h2 class="interactive-heading" id="'.$sanitizedTitle.'">'.$title.'</h2>';
+		echo "<script>console.log( 'heading worked " . $heading . "' );</script>";
+	}
+	else {
+	 	$iframeTitle = 'id="'.$sanitizedTitle.'"';
+		echo "<script>console.log( 'heading did not work so here is the url: " . $iframeTitle . "' );</script>";
 	}
 
 	if($atts['sharing'] === true || $atts['sharing'] == 'true') {
 		$sharing = chinapower_social_share($title, $URL, $iframe_twitter_pic_url);
 	}
 
-	return $heading.chinapower_interactive_display_iframe($interactiveURL, $width, $height, $fallbackImg, $iframeResizeDisabled).$sharing;
+	return $heading.chinapower_interactive_display_iframe($interactiveURL, $jump, $width, $height, $fallbackImg, $iframeResizeDisabled, $iframeTitle).$sharing;
 
 }
 add_shortcode( 'interactive', 'chinapower_shortcode_interactive' );

--- a/wp-content/themes/chinapower/inc/custom-shortcodes.php
+++ b/wp-content/themes/chinapower/inc/custom-shortcodes.php
@@ -144,6 +144,7 @@ function chinapower_shortcode_interactive( $atts ) {
 	);
 
 	$interactiveURL = get_post_meta( $atts['id'], '_interactive_url', true );
+	$interactiveID = get_post_meta( $atts['id'], 'id');
 	$width = get_post_meta( $atts['id'], '_interactive_width', true );
 	$height = get_post_meta( $atts['id'], '_interactive_height', true );
 	$iframeResizeDisabled = get_post_meta( $atts['id'], '_interactive_iframeResizeDisabled', true );
@@ -165,8 +166,8 @@ function chinapower_shortcode_interactive( $atts ) {
 		echo "<script>console.log( 'heading worked " . $heading . "' );</script>";
 	}
 	else {
-	 	$iframeTitle = 'id="'.$sanitizedTitle.'"';
-		echo "<script>console.log( 'heading did not work so here is the url: " . $iframeTitle . "' );</script>";
+	 	$iframeTitle = 'id="'.$sanitizedTitle.' (interactive)"';
+		echo "<script>console.log( 'iframeTitle in custom shortcode: " . $iframeTitle . "' );</script>";
 	}
 
 	if($atts['sharing'] === true || $atts['sharing'] == 'true') {

--- a/wp-content/themes/chinapower/inc/custom-shortcodes.php
+++ b/wp-content/themes/chinapower/inc/custom-shortcodes.php
@@ -173,7 +173,7 @@ function chinapower_shortcode_interactive( $atts ) {
 		$sharing = chinapower_social_share($title, $URL, $iframe_twitter_pic_url);
 	}
 
-	return $heading.chinapower_interactive_display_iframe($interactiveURL, $jump, $width, $height, $fallbackImg, $iframeResizeDisabled, $iframeID).$sharing;
+	return $heading.chinapower_interactive_display_iframe($interactiveURL, $width, $height, $iframeID, $fallbackImg, $iframeResizeDisabled).$sharing;
 
 }
 add_shortcode( 'interactive', 'chinapower_shortcode_interactive' );

--- a/wp-content/themes/chinapower/inc/custom-shortcodes.php
+++ b/wp-content/themes/chinapower/inc/custom-shortcodes.php
@@ -166,7 +166,7 @@ function chinapower_shortcode_interactive( $atts ) {
 		echo "<script>console.log( 'heading worked " . $heading . "' );</script>";
 	}
 	else {
-	 	$iframeTitle = 'id="'.$sanitizedTitle.' (interactive)"';
+	 	$iframeTitle = $sanitizedTitle;
 		echo "<script>console.log( 'iframeTitle in custom shortcode: " . $iframeTitle . "' );</script>";
 	}
 

--- a/wp-content/themes/chinapower/inc/custom-shortcodes.php
+++ b/wp-content/themes/chinapower/inc/custom-shortcodes.php
@@ -144,7 +144,6 @@ function chinapower_shortcode_interactive( $atts ) {
 	);
 
 	$interactiveURL = get_post_meta( $atts['id'], '_interactive_url', true );
-	$interactiveID = get_post_meta( $atts['id'], 'id');
 	$width = get_post_meta( $atts['id'], '_interactive_width', true );
 	$height = get_post_meta( $atts['id'], '_interactive_height', true );
 	$iframeResizeDisabled = get_post_meta( $atts['id'], '_interactive_iframeResizeDisabled', true );

--- a/wp-content/themes/chinapower/inc/custom-shortcodes.php
+++ b/wp-content/themes/chinapower/inc/custom-shortcodes.php
@@ -162,10 +162,10 @@ function chinapower_shortcode_interactive( $atts ) {
 
 	if($atts['toc'] === true || $atts['toc'] == 'true') {
 		$heading = '<h2 class="interactive-heading" id="'.$sanitizedTitle.'">'.$title.'</h2>';
+		$iframeID = null;
 	}
 	else {
 	 	$iframeID = $sanitizedTitle;
-		echo "<script>console.log( 'iframeID in custom shortcode: " . $iframeID . "' );</script>"; //correctly renders title
 	}
 
 	if($atts['sharing'] === true || $atts['sharing'] == 'true') {

--- a/wp-content/themes/chinapower/inc/custom-shortcodes.php
+++ b/wp-content/themes/chinapower/inc/custom-shortcodes.php
@@ -163,18 +163,17 @@ function chinapower_shortcode_interactive( $atts ) {
 
 	if($atts['toc'] === true || $atts['toc'] == 'true') {
 		$heading = '<h2 class="interactive-heading" id="'.$sanitizedTitle.'">'.$title.'</h2>';
-		echo "<script>console.log( 'heading worked " . $heading . "' );</script>";
 	}
 	else {
-	 	$iframeTitle = $sanitizedTitle;
-		echo "<script>console.log( 'iframeTitle in custom shortcode: " . $iframeTitle . "' );</script>";
+	 	$iframeID = $sanitizedTitle;
+		echo "<script>console.log( 'iframeID in custom shortcode: " . $iframeID . "' );</script>"; //correctly renders title
 	}
 
 	if($atts['sharing'] === true || $atts['sharing'] == 'true') {
 		$sharing = chinapower_social_share($title, $URL, $iframe_twitter_pic_url);
 	}
 
-	return $heading.chinapower_interactive_display_iframe($interactiveURL, $jump, $width, $height, $fallbackImg, $iframeResizeDisabled, $iframeTitle).$sharing;
+	return $heading.chinapower_interactive_display_iframe($interactiveURL, $jump, $width, $height, $fallbackImg, $iframeResizeDisabled, $iframeID).$sharing;
 
 }
 add_shortcode( 'interactive', 'chinapower_shortcode_interactive' );


### PR DESCRIPTION
This definitely isn't ready, but I'm committing it to ask questions about shortcode and php for the chinapower site.

My understanding is that `custom-shortcodes` allows you to create custom content types that can be used throughout the rest of the site, versus `cpt-interactives` which will control what directly renders onto the dom using the shortcode. For this particular feature (which occurs when an id is added to the iframe when `toc=false` instead of a `$heading` when `toc=true`), I created `$iframeID`, which I set equal to the `$sanitizedTitle`, which was passed on as a variable.

Knowing that the variables are passed on are order-sensitive, in `cpt-interactives.php`, I added it to the rendered iframe code. The jump-to works now (and the chart id is added to the iframe itself), but it doesn't seem to jump exactly to the chart on the page. 

I'm not sure how to rectify this, or if it's a caching problem. Should I be looking at the `post-nav.js`, particularly `if(ID =="#jump" ...`? If you have the time today - would you be able to let me if if I'm on the right track? 

(I also left the console logs but will erase those before the final push). 

EDIT: added `id=jump`, which does seem to help the jumping problem?

