### PR TITLE
Update/toolbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,9 @@ Thumbs.db
 # track these mu-plugins, plugins, and themes
 # add your own entries here
 !wp-content/plugins/chinapower-google-analytics.php
+!wp-content/plugins/toolbar-cpp
+!wp-content/plugins/toolbar-footnote
+!wp-content/plugins/toolbar-fullwidth
 !wp-content/themes/chinapower
 
 wp-content/themes/chinapower/.sass-cache

--- a/wp-content/plugins/toolbar-cpp/cpp.js
+++ b/wp-content/plugins/toolbar-cpp/cpp.js
@@ -18,7 +18,7 @@
   wp.richText.registerFormatType(
     'cpp/sample-output', {
       title: 'CPP Shortcode',
-      tagName: 'div',
+      tagName: 'cpp',
       className: null,
       edit: cppShortcode
     }

--- a/wp-content/plugins/toolbar-cpp/cpp.js
+++ b/wp-content/plugins/toolbar-cpp/cpp.js
@@ -18,7 +18,7 @@
   wp.richText.registerFormatType(
     'cpp/sample-output', {
       title: 'CPP Shortcode',
-      tagName: 'samp',
+      tagName: 'div',
       className: null,
       edit: cppShortcode
     }

--- a/wp-content/plugins/toolbar-cpp/cpp.js
+++ b/wp-content/plugins/toolbar-cpp/cpp.js
@@ -1,0 +1,26 @@
+(function (wp) {
+  const cppShortcode = function (props) {
+    return wp.element.createElement(
+      wp.editor.RichTextToolbarButton, {
+        icon: '',
+        title: 'CPP',
+        onClick: function () {
+          props.onChange(wp.richText.insert(
+            props.value,
+            valueToInsert = '[cpp]',
+            startIndex = props.value.start,
+            endIndex = props.value.end
+          ))
+        }
+      }
+    )
+  }
+  wp.richText.registerFormatType(
+    'cpp/sample-output', {
+      title: 'CPP Shortcode',
+      tagName: 'samp',
+      className: null,
+      edit: cppShortcode
+    }
+  )
+})(window.wp)

--- a/wp-content/plugins/toolbar-cpp/cpp.php
+++ b/wp-content/plugins/toolbar-cpp/cpp.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: CPP Icon
+Plugin Name: Toolbar - CPP Icon
 */
 
 function cpp_script_register() {

--- a/wp-content/plugins/toolbar-cpp/cpp.php
+++ b/wp-content/plugins/toolbar-cpp/cpp.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: Toolbar - CPP Icon
+Plugin Name: CSIS Toolbar - CPP
 */
 
 function cpp_script_register() {

--- a/wp-content/plugins/toolbar-cpp/cpp.php
+++ b/wp-content/plugins/toolbar-cpp/cpp.php
@@ -1,0 +1,18 @@
+<?php
+/*
+Plugin Name: CPP Icon
+*/
+
+function cpp_script_register() {
+    wp_register_script(
+        'cpp.js',
+        plugins_url( 'cpp.js', __FILE__ ),
+        array( 'wp-rich-text', 'wp-element', 'wp-editor' )
+    );
+}
+add_action( 'init', 'cpp_script_register' );
+
+function cpp_enqueue_assets_editor() {
+    wp_enqueue_script( 'cpp.js' );
+}
+add_action( 'enqueue_block_editor_assets', 'cpp_enqueue_assets_editor' );

--- a/wp-content/plugins/toolbar-cpp/cpp.php
+++ b/wp-content/plugins/toolbar-cpp/cpp.php
@@ -1,7 +1,9 @@
 <?php
-/*
-Plugin Name: CSIS Toolbar - CPP
-*/
+/**
+  * Plugin Name:    CSIS Toolbar - CPP
+  * Description:    Affixes a button to the editor toolbar which will add the China Power symbol shortcode to the block.
+  * Version:        1.0
+**/
 
 function cpp_script_register() {
     wp_register_script(

--- a/wp-content/plugins/toolbar-footnote/footnote.js
+++ b/wp-content/plugins/toolbar-footnote/footnote.js
@@ -1,0 +1,26 @@
+(function (wp) {
+  const footnoteShortcode = function (props) {
+    return wp.element.createElement(
+      wp.editor.RichTextToolbarButton, {
+        icon: '',
+        title: 'Footnote',
+        onClick: function () {
+          props.onChange(wp.richText.insert(
+            props.value,
+            valueToInsert = '[note][/note]',
+            startIndex = props.value.start,
+            endIndex = props.value.end
+          ))
+        }
+      }
+    )
+  }
+  wp.richText.registerFormatType(
+    'footnote/sample-output', {
+      title: 'footnote Shortcode',
+      tagName: 'div',
+      className: null,
+      edit: footnoteShortcode
+    }
+  )
+})(window.wp)

--- a/wp-content/plugins/toolbar-footnote/footnote.js
+++ b/wp-content/plugins/toolbar-footnote/footnote.js
@@ -18,7 +18,7 @@
   wp.richText.registerFormatType(
     'footnote/sample-output', {
       title: 'footnote Shortcode',
-      tagName: 'div',
+      tagName: 'footnote',
       className: null,
       edit: footnoteShortcode
     }

--- a/wp-content/plugins/toolbar-footnote/footnote.php
+++ b/wp-content/plugins/toolbar-footnote/footnote.php
@@ -1,7 +1,10 @@
 <?php
-/*
-Plugin Name: CSIS Toolbar - Footnote
-*/
+/**
+  * Plugin Name:    CSIS Toolbar - Footnote
+  * Description:    Affixes a button to the editor toolbar which will add the footnote shortcode to the block.
+  * Version:        1.0
+**/
+
 
 function footnote_script_register() {
     wp_register_script(

--- a/wp-content/plugins/toolbar-footnote/footnote.php
+++ b/wp-content/plugins/toolbar-footnote/footnote.php
@@ -1,0 +1,18 @@
+<?php
+/*
+Plugin Name: Toolbar - Footnote
+*/
+
+function footnote_script_register() {
+    wp_register_script(
+        'footnote.js',
+        plugins_url( 'footnote.js', __FILE__ ),
+        array( 'wp-rich-text', 'wp-element', 'wp-editor' )
+    );
+}
+add_action( 'init', 'footnote_script_register' );
+
+function footnote_enqueue_assets_editor() {
+    wp_enqueue_script( 'footnote.js' );
+}
+add_action( 'enqueue_block_editor_assets', 'footnote_enqueue_assets_editor' );

--- a/wp-content/plugins/toolbar-footnote/footnote.php
+++ b/wp-content/plugins/toolbar-footnote/footnote.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: Toolbar - Footnote
+Plugin Name: CSIS Toolbar - Footnote
 */
 
 function footnote_script_register() {

--- a/wp-content/plugins/toolbar-fullwidth/full-width.php
+++ b/wp-content/plugins/toolbar-fullwidth/full-width.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Plugin Name: Toolbar - Full Width
+Plugin Name: CSIS Toolbar - FullWidth
 */
 
 function full_width_script_register() {

--- a/wp-content/plugins/toolbar-fullwidth/full-width.php
+++ b/wp-content/plugins/toolbar-fullwidth/full-width.php
@@ -1,0 +1,18 @@
+<?php
+/*
+Plugin Name: Toolbar - Full Width
+*/
+
+function full_width_script_register() {
+    wp_register_script(
+        'fullWidth.js',
+        plugins_url( 'fullWidth.js', __FILE__ ),
+        array( 'wp-rich-text', 'wp-element', 'wp-editor' )
+    );
+}
+add_action( 'init', 'full_width_script_register' );
+
+function full_width_enqueue_assets_editor() {
+    wp_enqueue_script( 'fullWidth.js' );
+}
+add_action( 'enqueue_block_editor_assets', 'full_width_enqueue_assets_editor' );

--- a/wp-content/plugins/toolbar-fullwidth/full-width.php
+++ b/wp-content/plugins/toolbar-fullwidth/full-width.php
@@ -1,7 +1,9 @@
 <?php
-/*
-Plugin Name: CSIS Toolbar - FullWidth
-*/
+/**
+  * Plugin Name:    CSIS Toolbar - FullWidth
+  * Description:    Affixes a button to the editor toolbar which will add the fullwidth shortcode to the block.
+  * Version:        1.0
+**/
 
 function full_width_script_register() {
     wp_register_script(

--- a/wp-content/plugins/toolbar-fullwidth/fullWidth.js
+++ b/wp-content/plugins/toolbar-fullwidth/fullWidth.js
@@ -1,0 +1,26 @@
+(function (wp) {
+  const fullWidthShortcode = function (props) {
+    return wp.element.createElement(
+      wp.editor.RichTextToolbarButton, {
+        icon: '',
+        title: 'FullWidth',
+        onClick: function () {
+          props.onChange(wp.richText.insert(
+            props.value,
+            valueToInsert = '[fullWidth width=""][/fullWidth]',
+            startIndex = props.value.start,
+            endIndex = props.value.end
+          ))
+        }
+      }
+    )
+  }
+  wp.richText.registerFormatType(
+    'full-width/sample-output', {
+      title: 'FullWidth Shortcode',
+      tagName: 'fullwidth',
+      className: null,
+      edit: fullWidthShortcode
+    }
+  )
+})(window.wp)


### PR DESCRIPTION
This is the initial pass through of adding buttons for different shortcodes into the toolbar.

So far CPP, Footnote, and fullWidth all have been added. 

This works, however I'm still working on implementing a better way to use them. As of right now they're format buttons similar to how we first added the bomber shortcode into Aerospace. I remember we determined that wasn't the most optimal way. I know you shared this tutorial with me, https://wordpress.org/gutenberg/handbook/designers-developers/developers/packages/packages-editor/, I'm still trying to figure out that code. 

To use these new buttons properly the user first click's the format they want, then they add the content inside of the shortcode tags.

I also had a question on the fullWidth shortcode, is the width style property doing anything specific? I noticed the style is not active in the inspector. 

![Screen Shot 2019-05-17 at 11 55 00 AM](https://user-images.githubusercontent.com/30706065/57940541-acbee880-789a-11e9-85dd-803f5d96d9c5.png)


I also found this tutorial which might prove useful when we want to convert some of the other shortcodes into blocks: https://medium.com/@martindrapeau/wordpress-gutenberg-adapting-shortcodes-to-work-as-blocks-6063831eff47
