### PR TITLE
Conditionally add guest author name to citation

### DIFF
--- a/wp-content/themes/chinapower/inc/template-tags.php
+++ b/wp-content/themes/chinapower/inc/template-tags.php
@@ -236,8 +236,16 @@ function chinapower_relatedContent($rel){
 }
 
 function chinapower_citation() {
-	if ( get_the_modified_date() ) {
-		$modified_date = 'Updated ' . get_the_modified_date() . '. ';
-	}
-	return '<p class="cite-citation">China Power Team. "'.get_the_title().'" China Power. '.get_the_date().'. ' . $modified_date . 'Accessed '.current_time('F j, Y').'. '.get_the_permalink().'</p>';
+
+  $post_type = get_post_type( $post->ID );
+
+  if ( get_the_modified_date() ) {
+    $modified_date = 'Updated ' . get_the_modified_date() . '. ';
+  }
+
+  if ($post_type == 'guest_author_posts') {
+    return '<p class="cite-citation">' .get_field('guest_author'). '. "' .get_the_title(). '" China Power. '.get_the_date().'. ' . $modified_date . 'Accessed '.current_time('F j, Y').'. '.get_the_permalink().'</p>';
+  } else {
+    return '<p class="cite-citation">China Power Team. "' .get_the_title(). '" China Power. '.get_the_date().'. ' . $modified_date . 'Accessed '.current_time('F j, Y').'. '.get_the_permalink().'</p>';
+  }
 }


### PR DESCRIPTION
# What is this

Currently, all posts of all types have a "citation" section at the bottom that lists the author as "China Power Team.". This was hardcoded into our `chinapower_citation()` function. On 3/21, Brian asked if there was a way to update this for guest author posts to reflect the guest author name and _not_ the CPP team. 

**Current Problem**
<img width="424" alt="Screenshot 2023-03-22 at 11 46 51 AM" src="https://user-images.githubusercontent.com/41589348/226960280-32075772-f330-4565-ac0f-84c846afa181.png">

# What's the fix

## Add ACF plugin and Guest Author Field
Add the [Advanced Custom Fields](https://www.advancedcustomfields.com/) plugin and create a "Guest Author" text field. Set it to display only if the post type is Guest Author Posts, and have it show up just below the title so the CPP team doesn't miss it.
<img width="729" alt="Screenshot 2023-03-22 at 11 49 50 AM" src="https://user-images.githubusercontent.com/41589348/226962088-9c0b7c12-7135-4e47-8e47-ac1636ccf5b7.png">


<img width="716" alt="Screenshot 2023-03-22 at 11 49 36 AM" src="https://user-images.githubusercontent.com/41589348/226962113-4b451824-9c4b-4a91-9ea6-febdaa86dd50.png">

<img width="479" alt="Screenshot 2023-03-22 at 11 51 23 AM" src="https://user-images.githubusercontent.com/41589348/226962508-8046f79a-61e2-4fc3-b246-604907ed3c4d.png">

## Update `chinapower_citation()` function
Get the post type, and if it's `guest_author_posts`, put the `guest_author` name before the post title instead of "China Power Team". Otherwise, keep the original citation code.

<img width="377" alt="Screenshot 2023-03-22 at 11 52 54 AM" src="https://user-images.githubusercontent.com/41589348/226962908-776db4af-aee8-4ec6-b5bd-c558d1ec7653.png">

