### PR TITLE
Create shortcode for printing guest author bios

### DIFF
--- a/wp-content/themes/chinapower/inc/custom-shortcodes.php
+++ b/wp-content/themes/chinapower/inc/custom-shortcodes.php
@@ -321,3 +321,31 @@ function chinapower_shortcode_viewpost( $atts ) {
 
 }
 add_shortcode( 'view-post', 'chinapower_shortcode_viewpost' );
+
+function guestAuthorBio() {
+	$guest_author = get_field('guest_author');
+	$guest_author_names = array();
+	$guest_author_IDs = array();
+	global $coauthors_plus;
+	$output = '';
+
+  if ($guest_author) {
+
+		foreach ($guest_author as $key => $name) {
+				array_push($guest_author_names, $name -> post_title);
+				array_push($guest_author_IDs, $name -> ID);
+		}
+
+
+		for ($i = 0; $i <= count($guest_author_IDs); $i++) {
+			
+			$coauthor_data = $coauthors_plus->get_coauthor_by( 'id', $guest_author_IDs[$i]);
+
+			$output .= '<i><p><b>' .$guest_author_names[$i]. '</b> '.$coauthor_data -> description . '</p></i>';
+		}
+	}
+
+	return $output;
+}
+
+add_shortcode('guest-author-bio', 'guestAuthorBio');


### PR DESCRIPTION
# What is this
A `guest-author-bio` shortcode for CPP users to put at the bottom of Guest Author Posts. It grabs the information in a Guest Author's bio, if any, and will print the name + bio information. 

# Why
Prevents CPP users from needing to type Guest Author information manually in every post by that author.

# Screenshots
<img width="1234" alt="Screenshot 2023-03-23 at 1 43 04 PM" src="https://user-images.githubusercontent.com/41589348/227294977-cbd9b88f-bfcb-42f7-9b2f-16b30116fcdb.png">

<img width="805" alt="Screenshot 2023-03-23 at 1 43 22 PM" src="https://user-images.githubusercontent.com/41589348/227295001-6dabf3bf-ed64-4a9d-8f88-f87b5dbdb50f.png">
